### PR TITLE
Update benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -102,7 +102,7 @@ jobs:
 
         $runsResponse = gh api "repos/$repo/actions/workflows/$workflowFile/runs?branch=next&event=push&status=success&per_page=50"
         $runs = ($runsResponse | ConvertFrom-Json).workflow_runs
-        $artifactId = $null
+        $baselineRunId = $null
 
         foreach ($run in $runs) {
           if ($run.id -eq ${{ github.run_id }}) {
@@ -115,20 +115,18 @@ jobs:
             Select-Object -First 1
 
           if ($artifact) {
-            $artifactId = $artifact.id
+            $baselineRunId = $run.id
             break
           }
         }
 
-        if (-not $artifactId) {
+        if (-not $baselineRunId) {
           Write-Host "No baseline artifact found for '$artifactName'."
           exit 0
         }
 
         New-Item -ItemType Directory -Force -Path baseline | Out-Null
-        gh api "repos/$repo/actions/artifacts/$artifactId/zip" --output baseline/baseline.zip
-        Expand-Archive -Path baseline/baseline.zip -DestinationPath baseline -Force
-        Remove-Item baseline/baseline.zip -Force
+        gh run download $baselineRunId --name $artifactName --dir baseline --repo $repo
 
         $baselineJson = Get-ChildItem -Path baseline -Filter "current-normalized.json" -Recurse | Select-Object -First 1
         if ($baselineJson) {

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ${{ fromJson(github.event_name == 'workflow_dispatch' && '["ubuntu-latest","windows-latest","macos-latest"]' || '["ubuntu-latest"]') }}
 
     steps:
     - name: Select target OS execution
@@ -44,11 +44,9 @@ jobs:
       run: |
         $eventName = "${{ github.event_name }}"
         $os = "${{ matrix.os }}"
-        $shouldRun = $false
+        $shouldRun = $true
 
-        if ($eventName -ne "workflow_dispatch") {
-          $shouldRun = $os -eq "ubuntu-latest"
-        } else {
+        if ($eventName -eq "workflow_dispatch") {
           switch ($os) {
             "ubuntu-latest" { $shouldRun = "${{ inputs.run_ubuntu }}" -eq "true"; break }
             "windows-latest" { $shouldRun = "${{ inputs.run_windows }}" -eq "true"; break }

--- a/src/FastCloner.Benchmark.CI/Reporting/BenchmarkDiffReporter.cs
+++ b/src/FastCloner.Benchmark.CI/Reporting/BenchmarkDiffReporter.cs
@@ -203,13 +203,13 @@ internal static class BenchmarkDiffReporter
         sb.AppendLine($"- Baseline generated (UTC): `{baseline.GeneratedAtUtc:yyyy-MM-dd HH:mm:ss}`");
         sb.AppendLine($"- Regression thresholds: time > `{FormatPercent(options.TimeThreshold)}`, alloc > `{FormatPercent(options.AllocThreshold)}`");
         sb.AppendLine();
-        sb.AppendLine("| Benchmark | FC Time (Baseline) | FC Time (Current) | Delta Time | FC Alloc (Baseline) | FC Alloc (Current) | Delta Alloc | Status |");
-        sb.AppendLine("|---|---:|---:|---|---:|---:|---|---|");
+        sb.AppendLine("| Status | Benchmark | FC Time (Baseline) | FC Time (Current) | Delta Time | FC Alloc (Baseline) | FC Alloc (Current) | Delta Alloc |");
+        sb.AppendLine("|---|---|---:|---:|---|---:|---:|---|");
 
         foreach (BaselineDiffItem item in diff.Items)
         {
             sb.AppendLine(
-                $"| {item.Benchmark} | {FormatNanoseconds(item.BaselineMeanNanoseconds)} | {FormatNanoseconds(item.CurrentMeanNanoseconds)} | {FormatCurrentDelta(item.TimeDeltaRatio, options.SameThreshold, "faster", "slower")} | {FormatBytes(item.BaselineAllocatedBytes)} | {FormatBytes(item.CurrentAllocatedBytes)} | {FormatCurrentDelta(item.AllocDeltaRatio, options.SameThreshold, "less", "more")} | {FormatStatus(item.Status)} |");
+                $"| {FormatStatus(item.Status)} | {item.Benchmark} | {FormatNanoseconds(item.BaselineMeanNanoseconds)} | {FormatNanoseconds(item.CurrentMeanNanoseconds)} | {FormatCurrentDelta(item.TimeDeltaRatio, options.SameThreshold, "faster", "slower")} | {FormatBytes(item.BaselineAllocatedBytes)} | {FormatBytes(item.CurrentAllocatedBytes)} | {FormatCurrentDelta(item.AllocDeltaRatio, options.SameThreshold, "less", "more")} |");
         }
 
         AppendStatusSection(sb, "Regressions", diff.Items.Where(item => item.Status == DiffStatus.Regression).ToList(), options.SameThreshold);
@@ -333,11 +333,11 @@ internal static class BenchmarkDiffReporter
     {
         return status switch
         {
-            DiffStatus.Regression => "regression",
-            DiffStatus.Improvement => "improvement",
-            DiffStatus.Mixed => "mixed",
-            DiffStatus.NewBenchmark => "new",
-            _ => "stable"
+            DiffStatus.Regression => "🔴",
+            DiffStatus.Improvement => "🟢",
+            DiffStatus.Mixed => "🟡",
+            DiffStatus.NewBenchmark => "🆕",
+            _ => "⚪"
         };
     }
 

--- a/src/FastCloner.Benchmark.CI/Reporting/BenchmarkResultParser.cs
+++ b/src/FastCloner.Benchmark.CI/Reporting/BenchmarkResultParser.cs
@@ -232,8 +232,7 @@ internal static class BenchmarkResultParser
             "us" => amount * 1000d,
             "ms" => amount * 1_000_000d,
             "s" => amount * 1_000_000_000d,
-            "μs" => amount * 1000d,
-            "µs" => amount * 1000d,
+            "μs" or "µs" => amount * 1000d,
             _ => amount
         };
     }

--- a/src/FastCloner/Code/FastClonerGenerator.cs
+++ b/src/FastCloner/Code/FastClonerGenerator.cs
@@ -976,7 +976,10 @@ internal static class FastClonerGenerator
             }
 
             Type runtimeType = item.GetType();
-            if (!hasOptionalTypeOverrides && FastClonerSafeTypes.CanReturnSameObject(runtimeType))
+            if (!hasOptionalTypeOverrides &&
+                ((!runtimeType.IsValueType && FastClonerSafeTypes.CanReturnSameObject(runtimeType)) ||
+                 runtimeType.IsPrimitive ||
+                 runtimeType.IsEnum))
             {
                 outArray[i] = item;
                 continue;

--- a/src/FastCloner/Code/FastClonerGenerator.cs
+++ b/src/FastCloner/Code/FastClonerGenerator.cs
@@ -68,6 +68,14 @@ internal static class FastClonerGenerator
         private FastClonerCache.TypeCloneMetadata? metadataB;
         private Func<object, FastCloneState, object>? recursiveB;
         private Func<object, FastCloneState, object>? worklistB;
+        private Type? typeC;
+        private FastClonerCache.TypeCloneMetadata? metadataC;
+        private Func<object, FastCloneState, object>? recursiveC;
+        private Func<object, FastCloneState, object>? worklistC;
+        private Type? typeD;
+        private FastClonerCache.TypeCloneMetadata? metadataD;
+        private Func<object, FastCloneState, object>? recursiveD;
+        private Func<object, FastCloneState, object>? worklistD;
         
         public void Resolve(
             Type runtimeType,
@@ -93,9 +101,37 @@ internal static class FastClonerGenerator
                 return;
             }
 
+            if (runtimeType == typeC && metadataC is not null)
+            {
+                metadata = metadataC;
+                recursiveCloner = recursiveC;
+                worklistCloner = worklistC;
+                PromoteThirdToFirst();
+                return;
+            }
+
+            if (runtimeType == typeD && metadataD is not null)
+            {
+                metadata = metadataD;
+                recursiveCloner = recursiveD;
+                worklistCloner = worklistD;
+                PromoteFourthToFirst();
+                return;
+            }
+
             metadata = GetTypeMetadata(runtimeType, state);
             recursiveCloner = metadata.RecursiveCloner;
             worklistCloner = metadata.WorklistCloner ?? recursiveCloner;
+
+            typeD = typeC;
+            metadataD = metadataC;
+            recursiveD = recursiveC;
+            worklistD = worklistC;
+            
+            typeC = typeB;
+            metadataC = metadataB;
+            recursiveC = recursiveB;
+            worklistC = worklistB;
 
             typeB = typeA;
             metadataB = metadataA;
@@ -127,6 +163,72 @@ internal static class FastClonerGenerator
             Func<object, FastCloneState, object>? previousWorklistA = worklistA;
             worklistA = worklistB;
             worklistB = previousWorklistA;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SuppressMessage("ReSharper", "SwapViaDeconstruction")]
+        private void PromoteThirdToFirst()
+        {
+            Type? previousTypeA = typeA;
+            Type? previousTypeB = typeB;
+            typeA = typeC;
+            typeB = previousTypeA;
+            typeC = previousTypeB;
+
+            FastClonerCache.TypeCloneMetadata? previousMetadataA = metadataA;
+            FastClonerCache.TypeCloneMetadata? previousMetadataB = metadataB;
+            metadataA = metadataC;
+            metadataB = previousMetadataA;
+            metadataC = previousMetadataB;
+
+            Func<object, FastCloneState, object>? previousRecursiveA = recursiveA;
+            Func<object, FastCloneState, object>? previousRecursiveB = recursiveB;
+            recursiveA = recursiveC;
+            recursiveB = previousRecursiveA;
+            recursiveC = previousRecursiveB;
+
+            Func<object, FastCloneState, object>? previousWorklistA = worklistA;
+            Func<object, FastCloneState, object>? previousWorklistB = worklistB;
+            worklistA = worklistC;
+            worklistB = previousWorklistA;
+            worklistC = previousWorklistB;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SuppressMessage("ReSharper", "SwapViaDeconstruction")]
+        private void PromoteFourthToFirst()
+        {
+            Type? previousTypeA = typeA;
+            Type? previousTypeB = typeB;
+            Type? previousTypeC = typeC;
+            typeA = typeD;
+            typeB = previousTypeA;
+            typeC = previousTypeB;
+            typeD = previousTypeC;
+
+            FastClonerCache.TypeCloneMetadata? previousMetadataA = metadataA;
+            FastClonerCache.TypeCloneMetadata? previousMetadataB = metadataB;
+            FastClonerCache.TypeCloneMetadata? previousMetadataC = metadataC;
+            metadataA = metadataD;
+            metadataB = previousMetadataA;
+            metadataC = previousMetadataB;
+            metadataD = previousMetadataC;
+
+            Func<object, FastCloneState, object>? previousRecursiveA = recursiveA;
+            Func<object, FastCloneState, object>? previousRecursiveB = recursiveB;
+            Func<object, FastCloneState, object>? previousRecursiveC = recursiveC;
+            recursiveA = recursiveD;
+            recursiveB = previousRecursiveA;
+            recursiveC = previousRecursiveB;
+            recursiveD = previousRecursiveC;
+
+            Func<object, FastCloneState, object>? previousWorklistA = worklistA;
+            Func<object, FastCloneState, object>? previousWorklistB = worklistB;
+            Func<object, FastCloneState, object>? previousWorklistC = worklistC;
+            worklistA = worklistD;
+            worklistB = previousWorklistA;
+            worklistC = previousWorklistB;
+            worklistD = previousWorklistC;
         }
     }
 
@@ -862,6 +964,7 @@ internal static class FastClonerGenerator
             return outArray;
         }
 
+        bool hasOptionalTypeOverrides = FastClonerCache.HasActiveTypeBehaviorOverrides;
         TypeCloneDispatchCache2 dispatch = default;
         for (int i = 0; i < l; i++)
         {
@@ -873,6 +976,12 @@ internal static class FastClonerGenerator
             }
 
             Type runtimeType = item.GetType();
+            if (!hasOptionalTypeOverrides && FastClonerSafeTypes.CanReturnSameObject(runtimeType))
+            {
+                outArray[i] = item;
+                continue;
+            }
+
             dispatch.Resolve(runtimeType, state, out FastClonerCache.TypeCloneMetadata metadata, out Func<object, FastCloneState, object>? recursiveCloner, out Func<object, FastCloneState, object>? worklistCloner);
 
             outArray[i] = (T)CloneClassInternalResolved(item, state, runtimeType, metadata, recursiveCloner, worklistCloner)!;

--- a/src/FastCloner/Code/FastClonerGenerator.cs
+++ b/src/FastCloner/Code/FastClonerGenerator.cs
@@ -976,7 +976,7 @@ internal static class FastClonerGenerator
             }
 
             Type runtimeType = item.GetType();
-            if (!hasOptionalTypeOverrides && FastClonerSafeTypes.CanReturnSameObject(runtimeType))
+            if (!hasOptionalTypeOverrides && FastClonerSafeTypes.CanReturnSameObject(runtimeType) && !runtimeType.IsValueType)
             {
                 outArray[i] = item;
                 continue;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core cloning hot paths (type-dispatch caching and class-array cloning fast paths), which could affect clone correctness/perf for polymorphic arrays and override scenarios. CI/reporting changes are low risk but could alter baseline selection and diff presentation.
> 
> **Overview**
> Updates the benchmark GitHub Actions workflow to run only `ubuntu-latest` by default (while keeping optional multi-OS runs for `workflow_dispatch`) and switches baseline retrieval to `gh run download` using the originating run id.
> 
> Improves benchmark diff output formatting by moving `Status` to the first column and rendering statuses as symbols (🔴/🟢/🟡/🆕/⚪), and slightly simplifies CSV time parsing by consolidating microsecond unit handling.
> 
> Optimizes cloning internals by expanding `TypeCloneDispatchCache2` from a 2-entry to a 4-entry promotion cache and adding a fast path in `Clone1DimArrayClassInternal` to directly copy safe/primitive/enum elements when no optional type behavior overrides are active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a010220c4803fb912c3ca8d2e1f14ff7f99214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->