### PR TITLE
Add IncludeSubtypes to enable subtype cloning for non-abstract classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,24 @@ Animal pet = new Dog { Name = "Buddy", Breed = "Labrador" };
 Animal clone = pet.FastDeepClone(); // Returns a cloned Dog
 ```
 
+For non-abstract base classes, you can opt into the same runtime subtype dispatch behavior:
+
+```cs
+[FastClonerClonable(IncludeSubtypes = true)]
+public class Device
+{
+    public string Name { get; set; }
+}
+
+public class Phone : Device
+{
+    public string OS { get; set; }
+}
+
+Device device = new Phone { Name = "Pixel", OS = "Android" };
+Device clone = device.FastDeepClone(); // Returns a cloned Phone
+```
+
 ### Explicitly Including Types
 
 When a type is only used dynamically (not visible at compile time), use `[FastClonerInclude]` to ensure the generator creates cloning code for it:

--- a/src/FastCloner.SourceGenerator.Shared/FastClonerClonableAttribute.cs
+++ b/src/FastCloner.SourceGenerator.Shared/FastClonerClonableAttribute.cs
@@ -14,6 +14,7 @@ public class FastClonerClonableAttribute : Attribute
     /// When true, generated clone code dispatches by runtime type and clones known subtypes similarly to abstract roots.
     /// This is ignored for abstract types, which always have subtype dispatch.
     /// This is ignored for structs, which cannot have subtypes.
+    /// This is ignored for sealed classes, which cannot be subclassed.
     /// </summary>
     /// <example>
     /// <code>

--- a/src/FastCloner.SourceGenerator.Shared/FastClonerClonableAttribute.cs
+++ b/src/FastCloner.SourceGenerator.Shared/FastClonerClonableAttribute.cs
@@ -10,6 +10,20 @@ namespace FastCloner.SourceGenerator.Shared;
 public class FastClonerClonableAttribute : Attribute
 {
     /// <summary>
+    /// Gets or sets whether subtype dispatch should be generated for this type.
+    /// When true, generated clone code dispatches by runtime type and clones known subtypes similarly to abstract roots.
+    /// This is ignored for abstract types, which always have subtype dispatch.
+    /// This is ignored for structs, which cannot have subtypes.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [FastClonerClonable(IncludeSubtypes = true)]
+    /// public class BaseType { }
+    /// </code>
+    /// </example>
+    public bool IncludeSubtypes { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the FastClonerClonableAttribute.
     /// </summary>
     public FastClonerClonableAttribute()

--- a/src/FastCloner.SourceGenerator/CloneCodeGenerator.cs
+++ b/src/FastCloner.SourceGenerator/CloneCodeGenerator.cs
@@ -208,7 +208,9 @@ internal sealed class CloneCodeGenerator
              return;
         }
         
-        if (_context.Model.IsAbstract)
+        bool needsSubtypeDispatcher = !_context.Model.IsStruct && (_context.Model.IsAbstract || _context.Model.IncludeSubtypes);
+
+        if (needsSubtypeDispatcher)
         {
             sb.AppendLine("            return InternalFastDeepClone(source, null);");
         }
@@ -274,11 +276,19 @@ internal sealed class CloneCodeGenerator
             sb.AppendLine("            if (source == null) return null;");
         }
         
-        if (_context.Model.IsAbstract)
+        bool needsSubtypeDispatcher = !_context.Model.IsStruct && (_context.Model.IsAbstract || _context.Model.IncludeSubtypes);
+        if (needsSubtypeDispatcher)
         {
-            WriteAbstractTypeDispatcher(typeName);
+            WriteSubtypeDispatcher(typeName, fullTypeName, includeRootTypeGuard: !_context.Model.IsAbstract);
+            if (_context.Model.IsAbstract)
+            {
+                sb.AppendLine("        }");
+                sb.AppendLine();
+                return;
+            }
         }
-        else if (_context.NeedsStateTracking)
+
+        if (_context.NeedsStateTracking)
         {
             _context.NeedsStateClass = true;
             sb.AppendLine("            var localState = state ?? new FcGeneratedCloneState();");
@@ -309,7 +319,7 @@ internal sealed class CloneCodeGenerator
         sb.AppendLine();
     }
 
-    private void WriteAbstractTypeDispatcher(string typeName)
+    private void WriteSubtypeDispatcher(string typeName, string fullTypeName, bool includeRootTypeGuard)
     {
         StringBuilder sb = _context.Source;
         EquatableArray<TypeModel> derivedTypes = _context.Model.DerivedTypes;
@@ -318,6 +328,14 @@ internal sealed class CloneCodeGenerator
         sb.AppendLine("            // Dispatch to concrete type cloner based on runtime type");
         sb.AppendLine("            var runtimeType = source.GetType();");
         sb.AppendLine();
+
+        string indent = "            ";
+        if (includeRootTypeGuard)
+        {
+            sb.AppendLine($"            if (runtimeType != typeof({fullTypeName}))");
+            sb.AppendLine("            {");
+            indent = "                ";
+        }
 
         foreach (TypeModel? derivedType in derivedTypes)
         {
@@ -331,29 +349,35 @@ internal sealed class CloneCodeGenerator
                     extensionClassName = $"{derivedType.Name}FastDeepCloneExtensions";
                 }
                 
-                sb.AppendLine($"            if (runtimeType == typeof({derivedTypeName}))");
-                sb.AppendLine($"                return ({typeName}){extensionClassName}.InternalFastDeepClone(({derivedTypeName})source, state);");
+                sb.AppendLine($"{indent}if (runtimeType == typeof({derivedTypeName}))");
+                sb.AppendLine($"{indent}    return ({typeName}){extensionClassName}.InternalFastDeepClone(({derivedTypeName})source, state);");
             }
             else
             {
                 string helperName = $"Clone{GetSafeTypeName(derivedType.Name)}";
                 _context.RegisterDerivedTypeHelper(derivedType, helperName);
                 
-                sb.AppendLine($"            if (runtimeType == typeof({derivedTypeName}))");
-                sb.AppendLine($"                return ({typeName}){helperName}(({derivedTypeName})source, state);");
+                sb.AppendLine($"{indent}if (runtimeType == typeof({derivedTypeName}))");
+                sb.AppendLine($"{indent}    return ({typeName}){helperName}(({derivedTypeName})source, state);");
             }
             sb.AppendLine();
         }
         
         if (_context.IsFastClonerAvailable)
         {
-            sb.AppendLine($"            return ({typeName}){CloneGeneratorContext.FastClonerDeepCloneCall("source")}!;");
+            sb.AppendLine($"{indent}return ({typeName}){CloneGeneratorContext.FastClonerDeepCloneCall("source")}!;");
         }
         else
         {
-            sb.AppendLine($"            throw new InvalidOperationException($\"Cannot clone unknown derived type {{runtimeType.FullName}} of {_context.Model.Name}. \" +");
-            sb.AppendLine("                \"Either add the derived type to this assembly, use [FastClonerInclude] to register it, \" +");
-            sb.AppendLine("                \"or install the FastCloner NuGet package for runtime fallback.\");");
+            sb.AppendLine($"{indent}throw new InvalidOperationException($\"Cannot clone unknown derived type {{runtimeType.FullName}} of {_context.Model.Name}. \" +");
+            sb.AppendLine($"{indent}    \"Either add the derived type to this assembly, use [FastClonerInclude] to register it, \" +");
+            sb.AppendLine($"{indent}    \"or install the FastCloner NuGet package for runtime fallback.\");");
+        }
+
+        if (includeRootTypeGuard)
+        {
+            sb.AppendLine("            }");
+            sb.AppendLine();
         }
     }
 

--- a/src/FastCloner.SourceGenerator/DerivedTypeCollector.cs
+++ b/src/FastCloner.SourceGenerator/DerivedTypeCollector.cs
@@ -137,11 +137,11 @@ internal static class DerivedTypeCollector
             RelatedTypes: EquatableArray<TypeModel>.Empty,
             NestedTypes: EquatableArray<MemberModel>.Empty,
             DerivedTypes: EquatableArray<TypeModel>.Empty,
-            nullabilityEnabled,
-            trustNullability,
+            NullabilityEnabled: nullabilityEnabled,
+            TrustNullability: trustNullability,
             PreserveIdentity: null,
             IsRefLikeType: false,
-            hasParameterlessConstructor,
+            HasParameterlessConstructor: hasParameterlessConstructor,
             CodeAnalysisAvailable: compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute") != null,
             TargetFramework: targetFramework);
     }
@@ -332,10 +332,10 @@ internal static class DerivedTypeCollector
             trustNullability,
             preserveIdentity,
             IsRefLikeType: false,
-            hasParameterlessConstructor,
+            HasParameterlessConstructor: hasParameterlessConstructor,
             CodeAnalysisAvailable: compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute") != null,
             TargetFramework: targetFramework,
-            new EquatableArray<string>(circRefLog.ToArray()));
+            CircularAnalysisLog: new EquatableArray<string>(circRefLog.ToArray()));
     }
     
     private static bool? GetPreserveIdentityFromType(INamedTypeSymbol symbol)

--- a/src/FastCloner.SourceGenerator/ImplicitTypeAnalyzer.cs
+++ b/src/FastCloner.SourceGenerator/ImplicitTypeAnalyzer.cs
@@ -204,7 +204,7 @@ internal static class ImplicitTypeAnalyzer
                 trustNullability,
                 PreserveIdentity: null,
                 IsRefLikeType: false,
-                hasParameterlessConstructor,
+                HasParameterlessConstructor: hasParameterlessConstructor,
                 CodeAnalysisAvailable: compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute") != null,
                 TargetFramework: targetFramework);
                 

--- a/src/FastCloner.SourceGenerator/TypeModel.cs
+++ b/src/FastCloner.SourceGenerator/TypeModel.cs
@@ -31,5 +31,6 @@ internal sealed record TypeModel(
     bool IsRefLikeType = false, // Whether the type is a ref struct (cannot be boxed/used as generic)
     bool HasParameterlessConstructor = true, // Whether the type has a public parameterless constructor (defaults to true for safety)
     bool CodeAnalysisAvailable = false, // Whether System.Diagnostics.CodeAnalysis attributes are available
+    bool IncludeSubtypes = false, // Whether subtype dispatch should be generated for this type
     TargetFramework TargetFramework = TargetFramework.NetStandard20, // Detected target framework for TFM-specific optimizations
     EquatableArray<string> CircularAnalysisLog = default) : IEquatable<TypeModel>;

--- a/src/FastCloner.SourceGenerator/TypeModelFactory.cs
+++ b/src/FastCloner.SourceGenerator/TypeModelFactory.cs
@@ -23,7 +23,8 @@ internal static class TypeModelFactory
             .Any(a => a.AttributeClass?.ToDisplayString() == "FastCloner.SourceGenerator.Shared.FastClonerSimulateNoRuntimeAttribute");
         bool trustNullability = symbol.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == "FastCloner.SourceGenerator.Shared.FastClonerTrustNullabilityAttribute");
-        bool includeSubtypes = GetIncludeSubtypesFromType(symbol);
+        bool requestedIncludeSubtypes = GetIncludeSubtypesFromType(symbol);
+        bool effectiveIncludeSubtypes = requestedIncludeSubtypes && !symbol.IsValueType && !symbol.IsSealed;
         bool? preserveIdentity = GetPreserveIdentityFromType(symbol);
         bool codeAnalysisAvailable = compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute") != null;
         
@@ -212,7 +213,7 @@ internal static class TypeModelFactory
         bool isRefLikeType = TypeAnalyzer.IsRefStructType(symbol);
         EquatableArray<TypeModel> derivedTypes = EquatableArray<TypeModel>.Empty;
         
-        if (symbol.IsAbstract || includeSubtypes)
+        if (symbol.IsAbstract || effectiveIncludeSubtypes)
         {
             List<TypeModel> derivedTypesList = DerivedTypeCollector.Collect(symbol, compilation, nullabilityEnabled, targetFramework);
             derivedTypes = new EquatableArray<TypeModel>(derivedTypesList.ToArray());
@@ -258,7 +259,7 @@ internal static class TypeModelFactory
             isRefLikeType,
             hasParameterlessConstructor,
             codeAnalysisAvailable,
-            includeSubtypes,
+            effectiveIncludeSubtypes,
             targetFramework,
             new EquatableArray<string>(circRefLog.ToArray()));
 

--- a/src/FastCloner.SourceGenerator/TypeModelFactory.cs
+++ b/src/FastCloner.SourceGenerator/TypeModelFactory.cs
@@ -23,6 +23,7 @@ internal static class TypeModelFactory
             .Any(a => a.AttributeClass?.ToDisplayString() == "FastCloner.SourceGenerator.Shared.FastClonerSimulateNoRuntimeAttribute");
         bool trustNullability = symbol.GetAttributes()
             .Any(a => a.AttributeClass?.ToDisplayString() == "FastCloner.SourceGenerator.Shared.FastClonerTrustNullabilityAttribute");
+        bool includeSubtypes = GetIncludeSubtypesFromType(symbol);
         bool? preserveIdentity = GetPreserveIdentityFromType(symbol);
         bool codeAnalysisAvailable = compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute") != null;
         
@@ -211,12 +212,12 @@ internal static class TypeModelFactory
         bool isRefLikeType = TypeAnalyzer.IsRefStructType(symbol);
         EquatableArray<TypeModel> derivedTypes = EquatableArray<TypeModel>.Empty;
         
-        if (symbol.IsAbstract)
+        if (symbol.IsAbstract || includeSubtypes)
         {
             List<TypeModel> derivedTypesList = DerivedTypeCollector.Collect(symbol, compilation, nullabilityEnabled, targetFramework);
             derivedTypes = new EquatableArray<TypeModel>(derivedTypesList.ToArray());
             
-            if (derivedTypesList.Count == 0 && !isFastClonerAvailable)
+            if (symbol.IsAbstract && derivedTypesList.Count == 0 && !isFastClonerAvailable)
             {
                 error = Diagnostic.Create(
                     new DiagnosticDescriptor(
@@ -257,6 +258,7 @@ internal static class TypeModelFactory
             isRefLikeType,
             hasParameterlessConstructor,
             codeAnalysisAvailable,
+            includeSubtypes,
             targetFramework,
             new EquatableArray<string>(circRefLog.ToArray()));
 
@@ -282,5 +284,24 @@ internal static class TypeModelFactory
             }
         }
         return null;
+    }
+
+    private static bool GetIncludeSubtypesFromType(INamedTypeSymbol symbol)
+    {
+        foreach (AttributeData attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.ToDisplayString() != "FastCloner.SourceGenerator.Shared.FastClonerClonableAttribute")
+                continue;
+
+            foreach (KeyValuePair<string, TypedConstant> namedArg in attr.NamedArguments)
+            {
+                if (namedArg is { Key: "IncludeSubtypes", Value.Value: bool includeSubtypes })
+                    return includeSubtypes;
+            }
+
+            return false;
+        }
+
+        return false;
     }
 }

--- a/src/FastCloner.Tests/AbstractClassTests.cs
+++ b/src/FastCloner.Tests/AbstractClassTests.cs
@@ -152,6 +152,32 @@ public class AbstractClassTests
 
     #endregion
 
+    #region Test Classes - Concrete Base with IncludeSubtypes
+
+    [FastClonerClonable(IncludeSubtypes = true)]
+    public class Device
+    {
+        public string? Name { get; set; }
+    }
+
+    public class Phone : Device
+    {
+        public string? OperatingSystem { get; set; }
+    }
+
+    [FastClonerClonable]
+    public class PlainDevice
+    {
+        public string? Name { get; set; }
+    }
+
+    public class PlainPhone : PlainDevice
+    {
+        public string? OperatingSystem { get; set; }
+    }
+
+    #endregion
+
     #region Tests - Basic Abstract Class Cloning
     
     [Test]
@@ -210,6 +236,74 @@ public class AbstractClassTests
         await Assert.That(clonedCat.Age).IsEqualTo(3);
         await Assert.That(clonedCat.Color).IsEqualTo("Orange");
         await Assert.That(clonedCat.IsIndoor).IsTrue();
+    }
+
+    [Test]
+    [SourceGeneratorCompatible]
+    public async Task ConcreteBase_WithIncludeSubtypes_Should_Dispatch_To_Derived_Cloner()
+    {
+        // Arrange
+        Phone phone = new Phone
+        {
+            Name = "MyPhone",
+            OperatingSystem = "Android"
+        };
+
+        // Act - Clone via concrete base type
+        Device device = phone;
+        Device? clone = device.FastDeepClone();
+
+        // Assert
+        await Assert.That(clone).IsNotNull();
+        await Assert.That(clone).IsTypeOf<Phone>();
+        await Assert.That(clone).IsNotSameReferenceAs(phone);
+
+        Phone clonedPhone = (Phone)clone!;
+        await Assert.That(clonedPhone.Name).IsEqualTo("MyPhone");
+        await Assert.That(clonedPhone.OperatingSystem).IsEqualTo("Android");
+    }
+
+    [Test]
+    [SourceGeneratorCompatible]
+    public async Task ConcreteBase_WithoutIncludeSubtypes_Should_Keep_Default_Behavior()
+    {
+        // Arrange
+        PlainPhone phone = new PlainPhone
+        {
+            Name = "LegacyPhone",
+            OperatingSystem = "Symbian"
+        };
+
+        // Act - Clone via concrete base type without IncludeSubtypes
+        PlainDevice device = phone;
+        PlainDevice? clone = device.FastDeepClone();
+
+        // Assert
+        await Assert.That(clone).IsNotNull();
+        await Assert.That(clone).IsTypeOf<PlainDevice>();
+        await Assert.That(clone).IsNotSameReferenceAs(phone);
+        await Assert.That(clone is PlainPhone).IsFalse();
+        await Assert.That(clone!.Name).IsEqualTo("LegacyPhone");
+    }
+
+    [Test]
+    [SourceGeneratorCompatible]
+    public async Task ConcreteBase_WithIncludeSubtypes_Should_Clone_Device_Instance()
+    {
+        // Arrange
+        Device device = new Device
+        {
+            Name = "BaseDevice"
+        };
+
+        // Act
+        Device? clone = device.FastDeepClone();
+
+        // Assert
+        await Assert.That(clone).IsNotNull();
+        await Assert.That(clone).IsTypeOf<Device>();
+        await Assert.That(clone).IsNotSameReferenceAs(device);
+        await Assert.That(clone!.Name).IsEqualTo("BaseDevice");
     }
 
     #endregion

--- a/src/FastCloner.Tests/AbstractClassTests.cs
+++ b/src/FastCloner.Tests/AbstractClassTests.cs
@@ -99,6 +99,18 @@ public class AbstractClassTests
         public string? Name { get; set; }
     }
 
+    [FastClonerClonable(IncludeSubtypes = true)]
+    public sealed class SealedDevice
+    {
+        public string? Name { get; set; }
+    }
+
+    [FastClonerClonable(IncludeSubtypes = true)]
+    public struct StructDevice
+    {
+        public int Id { get; set; }
+    }
+
     public abstract class Polygon : Shape
     {
         public int NumberOfSides { get; set; }
@@ -318,6 +330,43 @@ public class AbstractClassTests
         await Assert.That(clone).IsTypeOf<Device>();
         await Assert.That(clone).IsNotSameReferenceAs(device);
         await Assert.That(clone!.Name).IsEqualTo("BaseDevice");
+    }
+
+    [Test]
+    [SourceGeneratorCompatible]
+    public async Task SealedClass_WithIncludeSubtypes_Should_Clone_Normally()
+    {
+        // Arrange
+        SealedDevice device = new SealedDevice
+        {
+            Name = "Sealed"
+        };
+
+        // Act
+        SealedDevice? clone = device.FastDeepClone();
+
+        // Assert
+        await Assert.That(clone).IsNotNull();
+        await Assert.That(clone).IsTypeOf<SealedDevice>();
+        await Assert.That(clone).IsNotSameReferenceAs(device);
+        await Assert.That(clone!.Name).IsEqualTo("Sealed");
+    }
+
+    [Test]
+    [SourceGeneratorCompatible]
+    public async Task Struct_WithIncludeSubtypes_Should_Clone_Normally()
+    {
+        // Arrange
+        StructDevice device = new StructDevice
+        {
+            Id = 42
+        };
+
+        // Act
+        StructDevice clone = device.FastDeepClone();
+
+        // Assert
+        await Assert.That(clone.Id).IsEqualTo(42);
     }
 
     #endregion

--- a/src/FastCloner.Tests/AbstractClassTests.cs
+++ b/src/FastCloner.Tests/AbstractClassTests.cs
@@ -20,6 +20,12 @@ public class ExternalBird : AbstractClassTests.Pet
     public double Wingspan { get; set; }
     public bool CanFly { get; set; }
 }
+
+public class ExternalWatch : AbstractClassTests.IncludedDevice
+{
+    public string? FirmwareVersion { get; set; }
+}
+
 [SourceGeneratorCompatible]
 public class AbstractClassTests
 {
@@ -174,6 +180,14 @@ public class AbstractClassTests
     public class PlainPhone : PlainDevice
     {
         public string? OperatingSystem { get; set; }
+    }
+
+    [FastClonerClonable(IncludeSubtypes = true)]
+    [FastClonerDisableAutoDiscovery]
+    [FastClonerInclude(typeof(ExternalWatch))]
+    public class IncludedDevice
+    {
+        public string? Name { get; set; }
     }
 
     #endregion
@@ -595,6 +609,31 @@ public class AbstractClassTests
         await Assert.That(((ExternalDog)clones[0]!).Name).IsEqualTo("Buddy");
         await Assert.That(((ExternalCat)clones[1]!).FurColor).IsEqualTo("Orange");
         await Assert.That(((ExternalBird)clones[2]!).CanFly).IsTrue();
+    }
+
+    [Test]
+    [SourceGeneratorCompatible]
+    public async Task IncludeSubtypes_WithFastClonerInclude_ExternalSubtype_Should_Clone()
+    {
+        // Arrange
+        ExternalWatch watch = new ExternalWatch
+        {
+            Name = "Pixel Watch",
+            FirmwareVersion = "1.2.3"
+        };
+
+        // Act - clone via concrete base with IncludeSubtypes=true
+        IncludedDevice device = watch;
+        IncludedDevice? clone = device.FastDeepClone();
+
+        // Assert
+        await Assert.That(clone).IsNotNull();
+        await Assert.That(clone).IsTypeOf<ExternalWatch>();
+        await Assert.That(clone).IsNotSameReferenceAs(watch);
+
+        ExternalWatch clonedWatch = (ExternalWatch)clone!;
+        await Assert.That(clonedWatch.Name).IsEqualTo("Pixel Watch");
+        await Assert.That(clonedWatch.FirmwareVersion).IsEqualTo("1.2.3");
     }
 
     #endregion


### PR DESCRIPTION
This was written using mostly AI supervised by me.

Introduce IncludeSubtypes property to FastClonerClonableAttribute, allowing non-abstract base classes to opt into runtime subtype dispatch for FastDeepClone. Update code generation and type modeling to support this feature. Add documentation and tests to demonstrate and verify the new behavior.

```cs
[FastClonerClonable(IncludeSubtypes = true)]
public class Device
{
    public string Name { get; set; }
}

public class Phone : Device
{
    public string OS { get; set; }
}

Device device = new Phone { Name = "Pixel", OS = "Android" };
Device clone = device.FastDeepClone(); // Returns a cloned Phone
```

Closes #43